### PR TITLE
Move feed location

### DIFF
--- a/src/dukop/apps/calendar/urls.py
+++ b/src/dukop/apps/calendar/urls.py
@@ -19,5 +19,5 @@ urlpatterns = [
         views.EventDetailView.as_view(),
         name="event_detail",
     ),
-    path(r"feed", views.EventFeed(), name="feed"),
+    path(r"feed/ical/", views.EventFeed(), name="feed"),
 ]


### PR DESCRIPTION
We need to be able to host different feeds. Since django-ical is likely a separate component to any other webdav og RSS feeds, I think it makes sense to do:

/feed/ical/

Later, we can add stuff like:

/feed/ical/sphere/<id>/
/feed/ical/category/<id>/
/feed/ical/group/<id>/

(or make it querystrings)