### PR TITLE
Redirect view to redirect from old event URL location to new

### DIFF
--- a/src/dukop/apps/sync_old/views.py
+++ b/src/dukop/apps/sync_old/views.py
@@ -1,0 +1,30 @@
+from django.http.response import Http404
+from django.urls.base import reverse
+from django.utils.translation import activate
+from django.utils.translation import get_language
+from django.views.generic.base import RedirectView
+from dukop.apps.calendar.models import OldEventSync
+
+
+class RedirectOld(RedirectView):
+
+    permanent = True
+
+    def get_redirect_url(self, pk=0):
+
+        try:
+            event_sync = OldEventSync.objects.get(old_fk=pk)
+        except OldEventSync.DoesNotExist:
+            raise Http404()
+
+        cur_language = get_language()
+
+        try:
+            locale = self.request.GET.get("locale") or "en"
+            locale = locale[:2]
+            activate(locale)
+            url = reverse("calendar:event_detail", kwargs={"pk": event_sync.event.id})
+        finally:
+            activate(cur_language)
+
+        return url

--- a/src/dukop/urls.py
+++ b/src/dukop/urls.py
@@ -22,8 +22,9 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include
 from django.urls import path
+from dukop.apps.sync_old.views import RedirectOld
 
-urlpatterns = i18n_patterns(
+urlpatterns = [path("events/<int:pk>", RedirectOld.as_view())] + i18n_patterns(
     path("admin/", admin.site.urls),
     path("news/", include("dukop.apps.news.urls")),
     path("users/", include("dukop.apps.users.urls")),


### PR DESCRIPTION
Can't believe I didn't create an issue for this.

When someone visits an old link.. from Google, links in posts, emails etc.. it will be with the structure `/events/1234?locale=da`. This redirects people to the new location.