### PR TITLE
Fix of labels exiting container on timeline

### DIFF
--- a/src/dukop/apps/calendar/templates/calendar/index.html
+++ b/src/dukop/apps/calendar/templates/calendar/index.html
@@ -88,9 +88,12 @@
 
   {% for event_time in todays_events %}
     {% event_timeline_properties event_time as timeline %}
-    <div class="timeline__event timeline__event--color{% cycle "1" "2" "3" %} timeline__event--right" data-text="{{ event_time.event.name }}" title="{{ event_time.event.name }}"
-      style="word-wrap: break-word; width: {{ timeline.width_pct|unlocalize }}%; margin-left: {{ timeline.x_start_pct|unlocalize }}%">
-    </div>
+        <a href="{% url "calendar:event_detail" pk=event_time.event.pk slug=event_time.event.slug %}">
+          <div class="timeline__event timeline__event--color{% cycle "1" "2" "3" %} timeline__event--right" data-text="{{ event_time.event.name }}" title="{{ event_time.event.name }}" 
+            style="word-wrap: break-word; width: {{ timeline.width_pct|unlocalize }}%; margin-left: {{ timeline.x_start_pct|unlocalize }}%">
+          
+          </div>
+        </a>
   {% empty %}
     <div class="timeline__event timeline__event--right" data-text="{% trans "Nothing planned today, this is your chance to do something! Gather your people!" %}">
     </div>

--- a/src/dukop/apps/calendar/templates/calendar/index.html
+++ b/src/dukop/apps/calendar/templates/calendar/index.html
@@ -89,9 +89,8 @@
   {% for event_time in todays_events %}
     {% event_timeline_properties event_time as timeline %}
         <a href="{% url "calendar:event_detail" pk=event_time.event.pk slug=event_time.event.slug %}">
-          <div class="timeline__event timeline__event--color{% cycle "1" "2" "3" %} timeline__event--right" data-text="{{ event_time.event.name }}" title="{{ event_time.event.name }}" 
+          <div class="timeline__event timeline__event--color{% cycle "1" "2" "3" %} timeline__event--right" data-text="{{ event_time.event.name }}" title="{{ event_time.start|time:"H:i" }} {{ event_time.event.name }}" 
             style="word-wrap: break-word; width: {{ timeline.width_pct|unlocalize }}%; margin-left: {{ timeline.x_start_pct|unlocalize }}%">
-          
           </div>
         </a>
   {% empty %}
@@ -100,12 +99,44 @@
   {% endfor %}
 
     <div class="timeline__scale">
-      <div class="timeline__min">
-        08:00
+
+      <div class="timeline__hour-container">
+        <div class="timeline__min">
+          08:00  
+        </div>
+        <div class="timeline__hour">
+          10:00
+        </div>
+
+        <div class="timeline__hour">
+          12:00
+        </div>
+
+        <div class="timeline__hour">
+          14:00
+        </div>
+
+        <div class="timeline__hour">
+          16:00
+        </div>
+
+        <div class="timeline__hour">
+          18:00
+        </div>
+
+        <div class="timeline__hour">
+          20:00
+        </div>
+
+        <div class="timeline__hour">
+          22:00
+        </div>
+        <div class="timeline__max">
+          24:00
+        </div>
+        
       </div>
-      <div class="timeline__max">
-        24:00
-      </div>
+
       <div class="timeline__now" id="timeline__now"></div>
     </div>
 

--- a/src/dukop/apps/calendar/templates/calendar/index.html
+++ b/src/dukop/apps/calendar/templates/calendar/index.html
@@ -88,8 +88,8 @@
 
   {% for event_time in todays_events %}
     {% event_timeline_properties event_time as timeline %}
-    <div class="timeline__event timeline__event--color{% cycle "1" "2" "3" %} timeline__event--right" data-text="{{ event_time.event.name }}"
-      style="width: {{ timeline.width_pct|unlocalize }}%; margin-left: {{ timeline.x_start_pct|unlocalize }}%">
+    <div class="timeline__event timeline__event--color{% cycle "1" "2" "3" %} timeline__event--right" data-text="{{ event_time.event.name }}" title="{{ event_time.event.name }}"
+      style="word-wrap: break-word; width: {{ timeline.width_pct|unlocalize }}%; margin-left: {{ timeline.x_start_pct|unlocalize }}%">
     </div>
   {% empty %}
     <div class="timeline__event timeline__event--right" data-text="{% trans "Nothing planned today, this is your chance to do something! Gather your people!" %}">

--- a/src/dukop/apps/calendar/templates/calendar/index.html
+++ b/src/dukop/apps/calendar/templates/calendar/index.html
@@ -86,10 +86,11 @@
   <h1 class="title title--space">{% trans "Happening" %} <strong>{% trans "today" %}</strong></h1>
   <div class="timeline">
 
+  <div class="timeline-events">
   {% for event_time in todays_events %}
     {% event_timeline_properties event_time as timeline %}
         <a href="{% url "calendar:event_detail" pk=event_time.event.pk slug=event_time.event.slug %}">
-          <div class="timeline__event timeline__event--color{% cycle "1" "2" "3" %} timeline__event--right" data-text="{{ event_time.event.name }}" title="{{ event_time.start|time:"H:i" }} {{ event_time.event.name }}" 
+          <div class="timeline__event timeline__event--color{% cycle "1" "2" "3" %} timeline__event--right" data-text="{{ event_time.event.name }}" title="{{ event_time.start|time:"H:i" }} {{ event_time.event.name }}"
             style="word-wrap: break-word; width: {{ timeline.width_pct|unlocalize }}%; margin-left: {{ timeline.x_start_pct|unlocalize }}%">
           </div>
         </a>
@@ -97,12 +98,13 @@
     <div class="timeline__event timeline__event--right" data-text="{% trans "Nothing planned today, this is your chance to do something! Gather your people!" %}">
     </div>
   {% endfor %}
+  </div>
 
     <div class="timeline__scale">
 
       <div class="timeline__hour-container">
-        <div class="timeline__min">
-          08:00  
+        <div class="timeline__hour timeline__min">
+          08:00
         </div>
         <div class="timeline__hour">
           10:00
@@ -131,10 +133,10 @@
         <div class="timeline__hour">
           22:00
         </div>
-        <div class="timeline__max">
+        <div class="timeline__hour timeline__max">
           24:00
         </div>
-        
+
       </div>
 
       <div class="timeline__now" id="timeline__now"></div>

--- a/src/dukop/apps/calendar/templatetags/calendar_tags.py
+++ b/src/dukop/apps/calendar/templatetags/calendar_tags.py
@@ -7,6 +7,7 @@ from django.template.defaultfilters import truncatechars
 from django.urls.base import reverse
 from django.utils.html import linebreaks
 from django.utils.safestring import mark_safe
+from django.utils.timezone import localtime
 
 from .. import models
 from .. import utils
@@ -87,23 +88,26 @@ def event_timeline_properties(event_time, now=None):
     """
 
     if not now:
-        now = utils.get_now()
+        now = localtime(utils.get_now())
 
     hours_x_min = 8
     hours_x_max = 24
     hours_x = hours_x_max - hours_x_min
 
-    if event_time.start.date() < now.date() or event_time.start.hour < hours_x_min:
+    start = localtime(event_time.start)
+    end = localtime(event_time.end) if event_time.end else None
+
+    if start.date() < now.date() or start.hour < hours_x_min:
         x_start = hours_x_min
     else:
-        x_start = event_time.start.hour + (event_time.start.minute / 60.0)
+        x_start = start.hour + (start.minute / 60.0)
 
-    if not event_time.end:
+    if not end:
         x_end = x_start
-    elif event_time.end.date() > now.date() or event_time.end.hour >= hours_x_max:
+    elif end.date() > now.date() or end.hour >= hours_x_max:
         x_end = hours_x_max
     else:
-        x_end = event_time.end.hour + (event_time.end.minute / 60.0)
+        x_end = end.hour + (end.minute / 60.0)
 
     x_start_pct = 100.0 * float(x_start - hours_x_min) / hours_x
     x_end_pct = 100.0 * float(x_end - hours_x_min) / hours_x

--- a/src/dukop/static/css/_timeline.scss
+++ b/src/dukop/static/css/_timeline.scss
@@ -65,34 +65,31 @@
 .timeline__scale {
   border-top: 2px solid rgba(0, 0, 0, 0.7);
   margin: 20px 0 0px 0;
+  width: 100%;
 }
 
-.timeline__min {
-  float: left;
-  margin-right: 9px;
-  /*font-style: italic;*/
+.timeline-events {
+    width: 100%;
+    position: relative;
 }
 
 .timeline__max {
-  float: right;
-  /*font-style: italic;*/
+  width: 1% !important;
 }
 
 .timeline__hour {
-  /*font-style: italic;*/
+  text-align: left;
   font-size: 14px;
-}
-
-.timeline__hour-container > div  {
-  display: inline-block;
-  display: -moz-inline-box;
+  display: table-cell;
   *display: inline; /* For IE7 */
   zoom: 1; /* Trigger hasLayout */
-  width: 11.8%;
-  text-align: center;
-  margin-left: -.7rem;
+  width: 12.5%;
 }
 
+.timeline__hour-container {
+    width: 100%;
+    display: table;
+}
 
 .timeline__now {
   width: 20px;

--- a/src/dukop/static/css/_timeline.scss
+++ b/src/dukop/static/css/_timeline.scss
@@ -54,7 +54,7 @@
 
 .timeline__event--right::after {
   content: attr(data-text);
-  left: 35px;
+  /*left: 35px;*/
   position: absolute;
   display: block;
   width: 200px;

--- a/src/dukop/static/css/_timeline.scss
+++ b/src/dukop/static/css/_timeline.scss
@@ -69,13 +69,30 @@
 
 .timeline__min {
   float: left;
-  font-style: italic;
+  margin-right: 9px;
+  /*font-style: italic;*/
 }
 
 .timeline__max {
   float: right;
-  font-style: italic;
+  /*font-style: italic;*/
 }
+
+.timeline__hour {
+  /*font-style: italic;*/
+  font-size: 14px;
+}
+
+.timeline__hour-container > div  {
+  display: inline-block;
+  display: -moz-inline-box;
+  *display: inline; /* For IE7 */
+  zoom: 1; /* Trigger hasLayout */
+  width: 11.8%;
+  text-align: center;
+  margin-left: -.7rem;
+}
+
 
 .timeline__now {
   width: 20px;
@@ -96,4 +113,10 @@
   margin-left: 7px;
   content: '';
   border-left: 2px solid #666;
+}
+
+@media (max-width: 700px) {
+  .timeline__hour-container > div.timeline__hour {
+    display: none;
+  }
 }

--- a/src/dukop/static/js/main.js
+++ b/src/dukop/static/js/main.js
@@ -17,10 +17,7 @@ if (document.querySelector(".js-copy")) {
 }
 
 // Going through timeline events (with a mission to shorten the labels so it won't break the div's)
-// ... also, this commit also included a change that would put the data-text as the elements title, so a hover will show the full label
 for (var i = document.getElementsByClassName("timeline__event").length - 1; i >= 0; i--) {
-
-
 
    // Calculate the lenght of text and find the width of the surrounding box
    let lengthOfText = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text'), 16, "italic").width
@@ -28,10 +25,9 @@ for (var i = document.getElementsByClassName("timeline__event").length - 1; i >=
 
    // If the length seems to be wider than the width
    if (lengthOfText / widthOfElement > .9) {
-      let counter = 0; // Counting how much it runs
-      
+      let counter = 0; // Counting how much it runs      
       let allowedNumber = 1 // Starting this check, to see how wide a 1 character label is
-      
+   
       // Check, if there's more space (if we shortened it too much with the 1 characters from above)
       let stillMoreSpace = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text').substring(0, allowedNumber), 16, "italic").width < widthOfElement
       
@@ -42,8 +38,9 @@ for (var i = document.getElementsByClassName("timeline__event").length - 1; i >=
 
          // So if we're out of space, then let's settle on a good 'substring number' to shorten the label by
          if(!stillMoreSpace){
-            console.log("Settled on "+allowedNumber+" for now")
-            console.log("I ran "+counter+" times")
+            
+            // console.log("Settled on "+allowedNumber+" for now")
+            // console.log("I ran "+counter+" times")
 
             // Shortening and inserting the newDataText ...
             let newDataText = document.getElementsByClassName("timeline__event")[i].getAttribute('data-text').substring(0, allowedNumber) + '..'
@@ -54,7 +51,7 @@ for (var i = document.getElementsByClassName("timeline__event").length - 1; i >=
          }
 
          // Because this is a hacky solution, I check if it's running amok
-         if(counter > 50){
+         if(counter > 70){
             stillMoreSpace = false;
             console.log("Argh, cancelllll, I ran more than 50 times pr event!")
          }

--- a/src/dukop/static/js/main.js
+++ b/src/dukop/static/js/main.js
@@ -17,10 +17,42 @@ if (document.querySelector(".js-copy")) {
 }
 
 
+// Karl's trying to fix the positioning - but this approach didn't work, keeping it for one commit then removing
+
+// for (var i = document.getElementsByClassName("timeline__event").length - 1; i >= 0; i--) {
+//    if(document.getElementsByClassName("timeline__event")[i].style.marginLeft != "0%") {
+
+//       let element = document.getElementsByClassName("timeline__event")[i]
+//       let elementMarginLeft = element.style.marginLeft
+
+
+
+//       var percents = parseFloat(elementMarginLeft);
+//       console.log(percents)
+//       var parentWidth = element.parentElement.parentElement.getBoundingClientRect().width;
+//       console.log(parentWidth)
+
+//       var marginLeftPixels = (parentWidth*percents)/100;
+//       console.log('marginLeftPixels: '+marginLeftPixels)
+      
+//       let newMarginLeft =  marginLeftPixels / 100   // whaat to do, how to inverse? 
+
+//       let newMarginLeftPercentage = (newMarginLeft / parentWidth) * 100 + "%"
+
+//       console.log("marginLeft: "+elementMarginLeft)
+//       // console.log("newMarginLeft: "+newMarginLeft)
+//       console.log("newMarginLeftPercentage: "+newMarginLeftPercentage)
+
+//       // document.getElementsByClassName("timeline__event")[i].style.marginLeft = newMarginLeftPercentage
+//    }
+// }
+
 
 // Going through timeline events (with a mission to shorten the labels so it won't break the div's)
 // ... also, this commit also included a change that would put the data-text as the elements title, so a hover will show the full label
 for (var i = document.getElementsByClassName("timeline__event").length - 1; i >= 0; i--) {
+
+
 
    // Calculate the lenght of text and find the width of the surrounding box
    let lengthOfText = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text'), 16, "italic").width

--- a/src/dukop/static/js/main.js
+++ b/src/dukop/static/js/main.js
@@ -15,3 +15,81 @@ function copy() {
 if (document.querySelector(".js-copy")) {
    document.querySelector(".js-copy").addEventListener("click", copy);
 }
+
+
+
+// Going through timeline events (with a mission to shorten the labels so it won't break the div's)
+// ... also, this commit also included a change that would put the data-text as the elements title, so a hover will show the full label
+for (var i = document.getElementsByClassName("timeline__event").length - 1; i >= 0; i--) {
+
+   // Calculate the lenght of text and find the width of the surrounding box
+   let lengthOfText = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text'), 16, "italic").width
+   let widthOfElement = document.getElementsByClassName("timeline__event")[i].getBoundingClientRect().width
+
+   // If the length seems to be wider than the width
+   if (lengthOfText / widthOfElement > .9) {
+      let counter = 0; // Counting how much it runs
+      
+      let allowedNumber = 1 // Starting this check, to see how wide a 1 character label is
+      
+      // Check, if there's more space (if we shortened it too much with the 1 characters from above)
+      let stillMoreSpace = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text').substring(0, allowedNumber), 16, "italic").width < widthOfElement
+      
+      while (stillMoreSpace) {
+
+         // Checking again after last run updated the allowedNumber
+         stillMoreSpace = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text').substring(0, allowedNumber), 16, "italic").width + 55 < widthOfElement
+
+         // So if we're out of space, then let's settle on a good 'substring number' to shorten the label by
+         if(!stillMoreSpace){
+            console.log("Settled on "+allowedNumber+" for now")
+            console.log("I ran "+counter+" times")
+
+            // Shortening and inserting the newDataText ...
+            let newDataText = document.getElementsByClassName("timeline__event")[i].getAttribute('data-text').substring(0, allowedNumber) + '..'
+            document.getElementsByClassName("timeline__event")[i].setAttribute('data-text', newDataText)
+         } else {
+            ++allowedNumber // Trying with one more character
+            ++counter // Just counting, to make sure we're not eternal - see the next if
+         }
+
+         // Because this is a hacky solution, I check if it's running amok
+         if(counter > 50){
+            stillMoreSpace = false;
+            console.log("Argh, cancelllll, I ran more than 50 times pr event!")
+         }
+      }
+   }
+}
+
+
+// https://stackoverflow.com/a/4032497/4241528
+function measureText(pText, pFontSize, pStyle) {
+    var lDiv = document.createElement('div');
+
+    document.body.appendChild(lDiv);
+
+    if (pStyle != null) {
+        lDiv.style = pStyle;
+    }
+    lDiv.style.fontSize = "" + pFontSize + "px";
+    lDiv.style.position = "absolute";
+    lDiv.style.left = -1000;
+    lDiv.style.top = -1000;
+
+    lDiv.textContent = pText;
+
+    var lResult = {
+        width: lDiv.clientWidth,
+        height: lDiv.clientHeight
+    };
+
+    document.body.removeChild(lDiv);
+    lDiv = null;
+
+    return lResult;
+}
+
+
+
+

--- a/src/dukop/static/js/main.js
+++ b/src/dukop/static/js/main.js
@@ -16,38 +16,6 @@ if (document.querySelector(".js-copy")) {
    document.querySelector(".js-copy").addEventListener("click", copy);
 }
 
-
-// Karl's trying to fix the positioning - but this approach didn't work, keeping it for one commit then removing
-
-// for (var i = document.getElementsByClassName("timeline__event").length - 1; i >= 0; i--) {
-//    if(document.getElementsByClassName("timeline__event")[i].style.marginLeft != "0%") {
-
-//       let element = document.getElementsByClassName("timeline__event")[i]
-//       let elementMarginLeft = element.style.marginLeft
-
-
-
-//       var percents = parseFloat(elementMarginLeft);
-//       console.log(percents)
-//       var parentWidth = element.parentElement.parentElement.getBoundingClientRect().width;
-//       console.log(parentWidth)
-
-//       var marginLeftPixels = (parentWidth*percents)/100;
-//       console.log('marginLeftPixels: '+marginLeftPixels)
-      
-//       let newMarginLeft =  marginLeftPixels / 100   // whaat to do, how to inverse? 
-
-//       let newMarginLeftPercentage = (newMarginLeft / parentWidth) * 100 + "%"
-
-//       console.log("marginLeft: "+elementMarginLeft)
-//       // console.log("newMarginLeft: "+newMarginLeft)
-//       console.log("newMarginLeftPercentage: "+newMarginLeftPercentage)
-
-//       // document.getElementsByClassName("timeline__event")[i].style.marginLeft = newMarginLeftPercentage
-//    }
-// }
-
-
 // Going through timeline events (with a mission to shorten the labels so it won't break the div's)
 // ... also, this commit also included a change that would put the data-text as the elements title, so a hover will show the full label
 for (var i = document.getElementsByClassName("timeline__event").length - 1; i >= 0; i--) {


### PR DESCRIPTION
Calculate width of text and compare with width of label, then a while loop to test how much it can hold. So basically, find a suitable substring to shorten the label by. + when hovering the label, it shows the full text in popup on desktop

- Not responsive. If you resize, you want to refresh to set new width's / string lengths 
- Right now it console.logs, not ready for production
- Could be cool to make a smarter algorithm! Like a binary search or something to quickly settle on the optimal string length (because right now it's like: "how long would a 1 character substring be, okay what about a 2 character substring, okay what about a 3 character substring... " etc. 

