### PR TITLE
Quickest fix on earth: zoom out (zoom: 0.7) on timeline element

### DIFF
--- a/src/dukop/static/css/_timeline.scss
+++ b/src/dukop/static/css/_timeline.scss
@@ -112,13 +112,25 @@
   border-left: 2px solid #666;
 }
 
+
 @media (max-width: 700px) {
-  .timeline__hour-container > div.timeline__hour {
-    /*display: none;*/
-  }
 
   .timeline {  
     zoom: 0.7;
+  }
+
+  @-moz-document url-prefix() {
+    .timeline__hour-container > div.timeline__hour {
+      /*display: none;*/
+      font-size: 8.1px;
+    }
+
+    .timeline-events {
+      font-size: 10px;
+    }
+
+
+
   }
 
 }

--- a/src/dukop/static/css/_timeline.scss
+++ b/src/dukop/static/css/_timeline.scss
@@ -1,4 +1,7 @@
-.timeline {
+.timeline {  
+  
+  zoom: 0.7;
+
   margin: 20px auto 40px auto;
   max-width: 900px;
   position: relative;
@@ -114,6 +117,6 @@
 
 @media (max-width: 700px) {
   .timeline__hour-container > div.timeline__hour {
-    display: none;
+    /*display: none;*/
   }
 }

--- a/src/dukop/static/css/_timeline.scss
+++ b/src/dukop/static/css/_timeline.scss
@@ -1,7 +1,4 @@
 .timeline {  
-  
-  zoom: 0.7;
-
   margin: 20px auto 40px auto;
   max-width: 900px;
   position: relative;
@@ -119,4 +116,9 @@
   .timeline__hour-container > div.timeline__hour {
     /*display: none;*/
   }
+
+  .timeline {  
+    zoom: 0.7;
+  }
+
 }

--- a/src/dukop/static/js/main.js
+++ b/src/dukop/static/js/main.js
@@ -18,9 +18,14 @@ if (document.querySelector(".js-copy")) {
 
 // Going through timeline events (with a mission to shorten the labels so it won't break the div's)
 for (var i = document.getElementsByClassName("timeline__event").length - 1; i >= 0; i--) {
-
+   let lengthOfText = null;
    // Calculate the lenght of text and find the width of the surrounding box
-   let lengthOfText = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text'), 16, "italic").width
+   if(navigator.userAgent.toLowerCase().indexOf('firefox') > -1){
+      lengthOfText = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text'), 10, "italic").width
+   } else {
+      lengthOfText = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text'), 16, "italic").width
+   }
+
    let widthOfElement = document.getElementsByClassName("timeline__event")[i].getBoundingClientRect().width
 
    // If the length seems to be wider than the width
@@ -28,13 +33,22 @@ for (var i = document.getElementsByClassName("timeline__event").length - 1; i >=
       let counter = 0; // Counting how much it runs      
       let allowedNumber = 1 // Starting this check, to see how wide a 1 character label is
    
+      let stillMoreSpace = null;
       // Check, if there's more space (if we shortened it too much with the 1 characters from above)
-      let stillMoreSpace = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text').substring(0, allowedNumber), 16, "italic").width < widthOfElement
+      if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
+         stillMoreSpace = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text').substring(0, allowedNumber), 10, "italic").width < widthOfElement
+      } else {
+         stillMoreSpace = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text').substring(0, allowedNumber), 16, "italic").width < widthOfElement
+      }
       
       while (stillMoreSpace) {
 
          // Checking again after last run updated the allowedNumber
-         stillMoreSpace = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text').substring(0, allowedNumber), 16, "italic").width + 55 < widthOfElement
+         if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
+            stillMoreSpace = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text').substring(0, allowedNumber), 10, "italic").width + 55 < widthOfElement
+         } else {
+            stillMoreSpace = measureText(document.getElementsByClassName("timeline__event")[i].getAttribute('data-text').substring(0, allowedNumber), 16, "italic").width + 55 < widthOfElement
+         }
 
          // So if we're out of space, then let's settle on a good 'substring number' to shorten the label by
          if(!stillMoreSpace){


### PR DESCRIPTION
Before: 
<img width="454" alt="Screenshot 2022-03-07 at 21 13 48" src="https://user-images.githubusercontent.com/9819978/157110943-1ee85468-236d-4165-96c1-ad5442f70bfc.png">

After:
<img width="502" alt="Screenshot 2022-03-07 at 21 14 09" src="https://user-images.githubusercontent.com/9819978/157110996-fe3b6c63-dc70-45cf-b6d4-e258486c00ed.png">

