### PR TITLE
Download .ics for single event

### DIFF
--- a/src/dukop/apps/calendar/templates/calendar/includes/event_card.html
+++ b/src/dukop/apps/calendar/templates/calendar/includes/event_card.html
@@ -25,7 +25,7 @@
         {% if not event_hide_share %}
         <div class="card__sharing">
             <h5>{% trans "Sharing" %}</h5>
-            <p><a href="">Download til kalender (ICS)</a></p>
+            <p><a href="{% url "calendar:feed_event_ical" event_id=event.id %}">Download til kalender (ICS)</a></p>
             <p>
               {% trans "Copy URL for sharing:" %}
             <br>

--- a/src/dukop/apps/calendar/urls.py
+++ b/src/dukop/apps/calendar/urls.py
@@ -70,6 +70,7 @@ urlpatterns = [
     path("feed/sphere/ical/<int:sphere_id>/", feeds.EventFeed(), name="feed_ical"),
     path("feed/sphere/rss/<int:sphere_id>/", feeds.RssFeed(), name="feed_rss"),
     path("sphere/change/<int:pk>/", views.set_sphere_session, name="sphere_change"),
+    path("feed/event/<int:event_id>/", feeds.EventFeedDetail(), name="feed_event_ical"),
     path(
         "sphere/<int:sphere_id>/events/<date:pivot_date>/",
         views.EventListView.as_view(),


### PR DESCRIPTION
Download single event, set nice filenames on iCal feeds, limit to only published events

Fixes #153 